### PR TITLE
Add document interaction API support

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,22 +1,24 @@
 package hint
 
 type client struct {
-	Patient            PatientClient
-	OAuth              OAuthClient
-	Partner            PartnerClient
-	Practitioner       PractitionerClient
-	IntegrationRecords IntegrationRecordsClient
+	Patient              PatientClient
+	OAuth                OAuthClient
+	Partner              PartnerClient
+	Practitioner         PractitionerClient
+	IntegrationRecords   IntegrationRecordsClient
+	DocumentInteractions DocumentInteractionClient
 }
 
 var defaultClient = getC()
 
 func getC() *client {
 	return &client{
-		Patient:            &patientClient{B: GetBackend(), Key: Key},
-		OAuth:              &oauthClient{B: GetBackend(), Key: Key},
-		Partner:            &partnerClient{B: GetBackend(), Key: Key},
-		Practitioner:       &practitionerClient{B: GetBackend(), Key: Key},
-		IntegrationRecords: &integrationRecordsClient{B: GetBackend(), Key: Key},
+		Patient:              &patientClient{B: GetBackend(), Key: Key},
+		OAuth:                &oauthClient{B: GetBackend(), Key: Key},
+		Partner:              &partnerClient{B: GetBackend(), Key: Key},
+		Practitioner:         &practitionerClient{B: GetBackend(), Key: Key},
+		IntegrationRecords:   &integrationRecordsClient{B: GetBackend(), Key: Key},
+		DocumentInteractions: &documentInteractionClient{B: GetBackend(), Key: Key},
 	}
 }
 
@@ -34,6 +36,7 @@ type PracticeClient interface {
 	ListPatient(params *ListParams) *Iter
 	ListAllPractitioners() ([]*Practitioner, error)
 	GetIntegrationRecords(patientID string) ([]*IntegrationRecord, error)
+	CreateDocumentInteraction(patientID string, params *DocumentInteractionParams) (*DocumentInteraction, error)
 }
 
 // NewPracticeClient returns an implementation of practiceClient
@@ -62,6 +65,11 @@ func SetPartnerClient(c PartnerClient) {
 // SetPractitionerClient enables caller to provide a particular implementation of the practitioner client for mocking purposes.
 func SetPractitionerClient(c PractitionerClient) {
 	defaultClient.Practitioner = c
+}
+
+// SetDocumentInteractionsClient enables caller to provide a particular implementation of the document interactions client for mocking purposes.
+func SetDocumentInteractionsClient(c DocumentInteractionClient) {
+	defaultClient.DocumentInteractions = c
 }
 
 // NewPatient creates a new patient based on the params.
@@ -149,4 +157,14 @@ func GetIntegrationRecords(practiceKey, patientID string) ([]*IntegrationRecord,
 // GetIntegrationRecords gets all integration records for a patient.
 func (c *practiceClient) GetIntegrationRecords(patientID string) ([]*IntegrationRecord, error) {
 	return c.client.IntegrationRecords.Get(c.accessToken, patientID)
+}
+
+// CreateDocumentInteraction creates a document interaction on a patient.
+func CreateDocumentInteraction(practiceKey, patientID string, params *DocumentInteractionParams) (*DocumentInteraction, error) {
+	return defaultClient.DocumentInteractions.Create(practiceKey, patientID, params)
+}
+
+// CreateDocumentInteraction creates a document interaction on a patient.
+func (c *practiceClient) CreateDocumentInteraction(patientID string, params *DocumentInteractionParams) (*DocumentInteraction, error) {
+	return c.client.DocumentInteractions.Create(c.accessToken, patientID, params)
 }

--- a/document_interaction.go
+++ b/document_interaction.go
@@ -1,0 +1,86 @@
+package hint
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Allowed values for DocumentInteractionParams.Status / DocumentInteraction.Status.
+const (
+	DocumentInteractionStatusDraft    = "draft"
+	DocumentInteractionStatusSigned   = "signed"
+	DocumentInteractionStatusAddended = "addended"
+	DocumentInteractionStatusDeleted  = "deleted"
+	DocumentInteractionStatusFailed   = "failed"
+)
+
+// DocumentInteractionParams represents the fields used to create a document interaction on a patient.
+type DocumentInteractionParams struct {
+	Status                  string     `json:"status"`
+	Title                   string     `json:"title,omitempty"`
+	Body                    string     `json:"body,omitempty"`
+	Attachments             []string   `json:"attachments,omitempty"`
+	EventTimestamp          *time.Time `json:"event_timestamp,omitempty"`
+	IntegrationRecordID     string     `json:"integration_record_id,omitempty"`
+	IntegrationErrorMessage string     `json:"integration_error_message,omitempty"`
+	IntegrationWebLink      string     `json:"integration_web_link,omitempty"`
+}
+
+// Validate ensures that the required fields for creating a document interaction are present.
+func (p *DocumentInteractionParams) Validate() error {
+	if p.Status == "" {
+		return errors.New("status required")
+	}
+	return nil
+}
+
+// DocumentInteraction represents a document interaction recorded against a patient.
+type DocumentInteraction struct {
+	ID                      string     `json:"id"`
+	Body                    string     `json:"body,omitempty"`
+	EventTimestamp          time.Time  `json:"event_timestamp,omitempty"`
+	PatientAccess           bool       `json:"patient_access,omitempty"`
+	PatientID               string     `json:"patient_id,omitempty"`
+	Status                  string     `json:"status,omitempty"`
+	Title                   string     `json:"title,omitempty"`
+	Type                    string     `json:"type,omitempty"`
+	IntegrationErrorMessage string     `json:"integration_error_message,omitempty"`
+	IntegrationLastSyncedAt *time.Time `json:"integration_last_synced_at,omitempty"`
+	IntegrationRecordID     string     `json:"integration_record_id,omitempty"`
+	IntegrationSyncStatus   string     `json:"integration_sync_status,omitempty"`
+	IntegrationWebLink      string     `json:"integration_web_link,omitempty"`
+}
+
+// DocumentInteractionClient represents the interface for creating document interactions on a patient.
+type DocumentInteractionClient interface {
+	Create(practiceKey, patientID string, params *DocumentInteractionParams) (*DocumentInteraction, error)
+}
+
+type documentInteractionClient struct {
+	B   Backend
+	Key string
+}
+
+// NewDocumentInteractionClient returns an implementation of DocumentInteractionClient.
+func NewDocumentInteractionClient(backend Backend, key string) DocumentInteractionClient {
+	return &documentInteractionClient{
+		B:   backend,
+		Key: key,
+	}
+}
+
+func (c documentInteractionClient) Create(practiceKey, patientID string, params *DocumentInteractionParams) (*DocumentInteraction, error) {
+	if practiceKey == "" {
+		return nil, errors.New("practice_key required")
+	}
+	if patientID == "" {
+		return nil, errors.New("patient_id required")
+	}
+
+	documentInteraction := &DocumentInteraction{}
+	if _, err := c.B.Call("POST", fmt.Sprintf("/provider/patients/%s/interactions/document", patientID), practiceKey, params, documentInteraction); err != nil {
+		return nil, err
+	}
+	return documentInteraction, nil
+}


### PR DESCRIPTION
Hint recently added the ability to create document interactions on a patient. Expose it through the SDK the same way other resources are wired up, so partners can record a synced document (status, title, body, and integration linking fields) against a patient.