### PR TITLE
Make Base URL Configurable

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -10,20 +10,23 @@ import (
 	"time"
 )
 
+// https://developers.hint.com/reference/making-requests
 const (
-	prodAPIURL         = "https://api.hint.com/api"
-	stagingAPIURL      = "https://api.staging.hint.com/api"
+	ProdAPIURL         = "https://api.hint.com/api"
+	StagingAPIURL      = "https://api.staging.hint.com/api"
+	SandboxAPIURL      = "https://api.sandbox.hint.com/api"
 	prodProviderURL    = "https://provider.hint.com"
 	stagingProviderURL = "https://provider.staging.hint.com"
+	sandboxProviderURL = "https://provider.sandbox.hint.com"
 )
 
 // apiURL returns the production or staging url based on the
 // Testing bool
 func apiURL() string {
 	if Testing {
-		return stagingAPIURL
+		return StagingAPIURL
 	}
-	return prodAPIURL
+	return ProdAPIURL
 }
 
 // ProviderURL returns the production or staging url for where the provider
@@ -44,19 +47,41 @@ type Backend interface {
 // BackendConfiguration is the internal implementation for making HTTP calls to Hint.
 type BackendConfiguration struct {
 	HTTPClient *http.Client
+
+	// baseURL, when non-empty, overrides the base API URL used for requests.
+	// When empty the URL is determined by apiURL (the Testing flag).
+	baseURL string
 }
 
-// GetBackend returns the currently used backend in the binding.
+// GetBackend returns the currently used backend in the binding. The base API
+// URL is determined by the Testing flag.
 func GetBackend() Backend {
+	return getBackend("")
+}
+
+// getBackend returns a backend that issues requests against the given base API
+// URL. When baseURL is empty the URL is determined by apiURL (the Testing flag).
+func getBackend(baseURL string) BackendConfiguration {
 	return BackendConfiguration{
 		HTTPClient: httpClient,
+		baseURL:    baseURL,
 	}
+}
+
+// resolveBaseURL returns the base API URL for the backend, preferring an
+// explicitly configured baseURL and otherwise falling back to the Testing-based
+// default.
+func (s BackendConfiguration) resolveBaseURL() string {
+	if s.baseURL != "" {
+		return s.baseURL
+	}
+	return apiURL()
 }
 
 // Key is the Hint Partner API key used globally in the binding.
 var Key string
 
-// Testing indicates whether to use the staging or production URL
+// Testing indicates whether to use the staging, sandbox, or production URL
 var Testing bool
 
 var httpClient = &http.Client{Timeout: 30 * time.Second}
@@ -98,7 +123,7 @@ func (s BackendConfiguration) NewRequest(method, path, key string, body io.Reade
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	path = apiURL() + path
+	path = s.resolveBaseURL() + path
 
 	req, err := http.NewRequest(method, path, body)
 	if err != nil {

--- a/backend_test.go
+++ b/backend_test.go
@@ -1,0 +1,71 @@
+package hint
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolveBaseURL(t *testing.T) {
+	prevTesting := Testing
+	defer func() { Testing = prevTesting }()
+
+	t.Run("DefaultsToProduction", func(t *testing.T) {
+		Testing = false
+		if got := getBackend("").resolveBaseURL(); got != ProdAPIURL {
+			t.Fatalf("expected %q, got %q", ProdAPIURL, got)
+		}
+	})
+
+	t.Run("DefaultsToStagingWhenTesting", func(t *testing.T) {
+		Testing = true
+		if got := getBackend("").resolveBaseURL(); got != StagingAPIURL {
+			t.Fatalf("expected %q, got %q", StagingAPIURL, got)
+		}
+	})
+
+	t.Run("PrefersConfiguredBaseURL", func(t *testing.T) {
+		// Configured base URL should win regardless of the Testing flag.
+		const custom = "https://api.example.com/api"
+		Testing = true
+		if got := getBackend(custom).resolveBaseURL(); got != custom {
+			t.Fatalf("expected %q, got %q", custom, got)
+		}
+	})
+}
+
+func TestNewRequestUsesConfiguredBaseURL(t *testing.T) {
+	const custom = "https://api.example.com/api"
+	req, err := getBackend(custom).NewRequest("GET", "/provider/practitioners", "key", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := custom + "/provider/practitioners"; req.URL.String() != want {
+		t.Fatalf("expected request URL %q, got %q", want, req.URL.String())
+	}
+}
+
+func TestWithBaseURLRoutesCalls(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	// Point the client at the test server via the option. Set Testing to a
+	// value whose default URL would differ, to prove the option takes effect.
+	prevTesting := Testing
+	Testing = true
+	defer func() { Testing = prevTesting }()
+
+	client := NewPracticeClient("access-token", WithBaseURL(srv.URL))
+	if _, err := client.ListAllPractitioners(); err != nil {
+		t.Fatal(err)
+	}
+
+	if want := "/provider/practitioners"; gotPath != want {
+		t.Fatalf("expected request path %q, got %q", want, gotPath)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -11,14 +11,41 @@ type client struct {
 
 var defaultClient = getC()
 
-func getC() *client {
+// clientOptions holds the configurable settings applied when constructing a
+// client. Zero values indicate that the corresponding default should be used.
+type clientOptions struct {
+	baseURL string
+}
+
+// Option configures optional behavior of a client created via NewPracticeClient.
+type Option func(*clientOptions)
+
+// WithBaseURL configures the base API URL used for all calls made by the client.
+// When this option is not provided, the base URL defaults to the value derived
+// from the Testing flag (staging when true, production otherwise).
+//
+// The provided URL is used as-is as the prefix for request paths, so it should
+// include any scheme, host, and base path (e.g. "https://api.hint.com/api").
+func WithBaseURL(baseURL string) Option {
+	return func(o *clientOptions) {
+		o.baseURL = baseURL
+	}
+}
+
+func getC(opts ...Option) *client {
+	var options clientOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	backend := getBackend(options.baseURL)
 	return &client{
-		Patient:              &patientClient{B: GetBackend(), Key: Key},
-		OAuth:                &oauthClient{B: GetBackend(), Key: Key},
-		Partner:              &partnerClient{B: GetBackend(), Key: Key},
-		Practitioner:         &practitionerClient{B: GetBackend(), Key: Key},
-		IntegrationRecords:   &integrationRecordsClient{B: GetBackend(), Key: Key},
-		DocumentInteractions: &documentInteractionClient{B: GetBackend(), Key: Key},
+		Patient:              &patientClient{B: backend, Key: Key},
+		OAuth:                &oauthClient{B: backend, Key: Key},
+		Partner:              &partnerClient{B: backend, Key: Key},
+		Practitioner:         &practitionerClient{B: backend, Key: Key},
+		IntegrationRecords:   &integrationRecordsClient{B: backend, Key: Key},
+		DocumentInteractions: &documentInteractionClient{B: backend, Key: Key},
 	}
 }
 
@@ -39,11 +66,14 @@ type PracticeClient interface {
 	CreateDocumentInteraction(patientID string, params *DocumentInteractionParams) (*DocumentInteraction, error)
 }
 
-// NewPracticeClient returns an implementation of practiceClient
-func NewPracticeClient(accessToken string) PracticeClient {
+// NewPracticeClient returns an implementation of practiceClient. Options may be
+// supplied to customize the client, for example WithBaseURL to override the base
+// API URL used for calls. When no options are provided the client uses the base
+// URL derived from the Testing flag.
+func NewPracticeClient(accessToken string, opts ...Option) PracticeClient {
 	return &practiceClient{
 		accessToken: accessToken,
-		client:      getC(),
+		client:      getC(opts...),
 	}
 }
 


### PR DESCRIPTION
This change makes the base URL used by a client configurable per instance of the client, introduces the sandbox endpoint, and exposes the three default base urls for this purpose. The existing Testing fallback is still respected and points to Staging by default if testing.